### PR TITLE
convert config endpoint from bunny to glb

### DIFF
--- a/src/stores/MediaPropertyStore.js
+++ b/src/stores/MediaPropertyStore.js
@@ -968,7 +968,7 @@ class MediaPropertyStore {
           const metadataUrl = new URL(
             this.rootStore.network === "demo" ?
               "https://demov3.net955210.contentfabric.io/s/demov3" :
-              "https://main.srt.bunny.cfab.io/s/main"
+              "https://main.glb.contentfabric.io/s/main"
           );
 
           metadataUrl.pathname = UrlJoin(
@@ -1051,7 +1051,7 @@ class MediaPropertyStore {
         const metadataUrl = new URL(
           this.rootStore.network === "demo" ?
             "https://demov3.net955210.contentfabric.io/s/demov3" :
-            "https://main.srt.bunny.cfab.io/s/main"
+            "https://main.glb.contentfabric.io/s/main"
         );
 
         metadataUrl.pathname = UrlJoin(
@@ -1110,7 +1110,7 @@ class MediaPropertyStore {
                 const imageUrl = new URL(
                   this.rootStore.network === "demo" ?
                     "https://demov3.net955210.contentfabric.io/s/demov3" :
-                    "https://main.srt.bunny.cfab.io/s/main"
+                    "https://main.glb.contentfabric.io/s/main"
                 );
 
                 imageUrl.pathname = UrlJoin(imageUrl.pathname, "q", property.propertyHash, "meta/public/asset_metadata/info/image");

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -476,7 +476,7 @@ class RootStore {
       const client = yield ElvClient.FromConfigurationUrl({
         configUrl:
           EluvioConfiguration.network === "main" ?
-            "https://main.srt.bunny.cfab.io/s/main/config" :
+            "https://main.glb.contentfabric.io/s/main/config" :
             "https://demov3.net955210.contentfabric.io/config"
       });
 

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -691,7 +691,7 @@ export const NFTMediaInfo = ({nft, item, selectedMedia, selectedMediaPath, requi
         mediaLink = new URL(
           rootStore.network === "demo" ?
             "https://demov3.net955210.contentfabric.io/s/demov3" :
-            "https://main.srt.bunny.cfab.io/s/main"
+            "https://main.glb.contentfabric.io/s/main"
         );
 
         const filePath = selectedMedia.media_file["/"].split("/files/")[1];
@@ -865,7 +865,7 @@ export const LinkTargetHash = (link) => {
 export const StaticFabricUrl = ({libraryId, objectId, versionHash, writeToken, path="", authToken, resolve=true, width}) => {
   let url = new URL(
     rootStore.network === "main" ?
-      "https://main.srt.bunny.cfab.io/s/main" :
+      "https://main.glb.contentfabric.io/s/main" :
       "https://demov3.net955210.contentfabric.io"
   );
 


### PR DESCRIPTION

For WPA we had set the production "config" URL to http://main.srt.bunny.cfab.io to make API calls more local.  

but, the certificate for http://main.srt.bunny.cfab.io expires in 3 days

new URL is: http://main.glb.contentfabric.io

we need to deploy this before the 28th.

affected sites:
- https://wallet.contentfabric.io/
- https://wallet.dev.contentfabric.io/
- https://wallet.preview.contentfabric.io/

not affected:
- wallet.demov3
- cfab.io cores

