### PR TITLE
remove loader warnings & add serve-http target for ory dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bump-version": "npm --git-tag-version --no-commit-hooks version patch",
     "serve": "webpack-dev-server --hot --port 8090 --host=0.0.0.0",
     "serve-https": "webpack-dev-server --https --hot --port 8090 --host=0.0.0.0",
+    "serve-http": "webpack serve --env USE_HTTP --hot --port 8090 --host=0.0.0.0",
     "serve-frame-test": "ENTRY=test/frame.js webpack-dev-server --https --hot --port 8091 --host=0.0.0.0",
     "serve-client-test": "ENTRY=test/client.js webpack-dev-server --https --hot --port 8092 --host=0.0.0.0",
     "serve-login-test": "ENTRY=test/login.js webpack-dev-server --https --hot --port 8093 --host=0.0.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,9 @@ module.exports = (env) => {
   return {
     entry: process.env.ENTRY ? Path.resolve(__dirname, process.env.ENTRY) : Path.resolve(__dirname, "src/index.js"),
     target: "web",
+	cache: {
+	  type: "filesystem",
+	},
     output: {
       path: Path.resolve(__dirname, "dist"),
       publicPath: "/",
@@ -138,7 +141,14 @@ module.exports = (env) => {
                 }
               }
             },
-            "sass-loader"
+            {
+              loader: "sass-loader",
+              options: {
+                sassOptions: {
+                  silenceDeprecations: ["legacy-js-api", "import"]
+                }
+              }
+            }
           ]
         },
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,11 +60,13 @@ module.exports = (env) => {
         //webSocketURL: "auto://elv-test.io/ws",
         overlay: false
       },
-      https: {
-        key: fs.readFileSync("./https/private.key"),
-        cert: fs.readFileSync("./https/dev.local.crt"),
-        ca: fs.readFileSync("./https/private.pem")
-      },
+      ...(!env.USE_HTTP && {
+        https: {
+          key: fs.readFileSync("./https/private.key"),
+          cert: fs.readFileSync("./https/dev.local.crt"),
+          ca: fs.readFileSync("./https/private.pem")
+        }
+      }),
       historyApiFallback: true,
       allowedHosts: "all",
       port: 8090,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,9 +38,9 @@ module.exports = (env) => {
   return {
     entry: process.env.ENTRY ? Path.resolve(__dirname, process.env.ENTRY) : Path.resolve(__dirname, "src/index.js"),
     target: "web",
-	cache: {
-	  type: "filesystem",
-	},
+    cache: {
+      type: "filesystem",
+    },
     output: {
       path: Path.resolve(__dirname, "dist"),
       publicPath: "/",


### PR DESCRIPTION

look ok?

we got ory tunnel to work, but, had to use http instead of https...thus the new serve-http.  sorry that the env.USE_HTTP kinda is messy, couldn't find another way


can remove the 
```
cache: { type: "filesystem", }
```
if there are potential side-effects to worry about, eg, the need to occasionally need to clear it (`rm -rf node_modules/.cache/webpack`) if that's a thing.

---
### ory dev setup summary:

```
$ ory tunnel http://localhost:8090/ --project eloquent-carson-yt726m2tf6 --dev --port 3000 
$ npm run serve-http
```
with ory_configuration `"url": "http://localhost:3000/"`


